### PR TITLE
Make accessible to all Objects, use Bundler for dependency resolution, remove all runtime dependencies.

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.8.7-p299@attr_symbol
+rvm use --create 1.9.3@attr_symbol

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source :rubygems
+
+gemspec
+
+group :development do
+  gem 'jeweler'
+  gem 'shoulda', '~> 2.11.3'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 group :development do
   gem 'jeweler'
   gem 'shoulda', '~> 2.11.3'
+  gem 'activerecord', '~> 2.3.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     attr_symbol (0.0.4)
-      activerecord (~> 2.3.5)
 
 GEM
   remote: http://rubygems.org/
@@ -26,6 +25,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord (~> 2.3.5)
   attr_symbol!
   jeweler
   shoulda (~> 2.11.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,31 @@
+PATH
+  remote: .
+  specs:
+    attr_symbol (0.0.4)
+      activerecord (~> 2.3.5)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activerecord (2.3.14)
+      activesupport (= 2.3.14)
+    activesupport (2.3.14)
+    git (1.2.5)
+    jeweler (1.8.4)
+      bundler (~> 1.0)
+      git (>= 1.2.5)
+      rake
+      rdoc
+    json (1.7.5)
+    rake (0.9.2.2)
+    rdoc (3.12)
+      json (~> 1.4)
+    shoulda (2.11.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  attr_symbol!
+  jeweler
+  shoulda (~> 2.11.3)

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ begin
     gem.email = "jwinky+gems@gmail.com"
     gem.homepage = "http://github.com/jwinky/attr_symbol"
     gem.authors = ["Justin Wienckowski"]
-    gem.add_dependency "activerecord", "~> 2.3.5"
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError
@@ -25,13 +24,3 @@ Rake::TestTask.new(:test) do |test|
 end
 
 task :default => :test
-
-# require 'rake/rdoctask'
-# Rake::RDocTask.new do |rdoc|
-#   version = File.exist?('VERSION') ? File.read('VERSION') : ""
-# 
-#   rdoc.rdoc_dir = 'rdoc'
-#   rdoc.title = "attr_symbol #{version}"
-#   rdoc.rdoc_files.include('README*')
-#   rdoc.rdoc_files.include('lib/**/*.rb')
-# end

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,7 @@ begin
     gem.email = "jwinky+gems@gmail.com"
     gem.homepage = "http://github.com/jwinky/attr_symbol"
     gem.authors = ["Justin Wienckowski"]
-    gem.add_development_dependency "shoulda", ">= 2.11.3"
-    gem.add_dependency "activerecord", ">= 2.3.5"
+    gem.add_dependency "activerecord", "~> 2.3.5"
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError
@@ -25,29 +24,14 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-begin
-  require 'rcov/rcovtask'
-  Rcov::RcovTask.new do |test|
-    test.libs << 'test'
-    test.pattern = 'test/**/test_*.rb'
-    test.verbose = true
-  end
-rescue LoadError
-  task :rcov do
-    abort "RCov is not available. In order to run rcov, you must: sudo gem install spicycode-rcov"
-  end
-end
-
-task :test => :check_dependencies
-
 task :default => :test
 
-require 'rake/rdoctask'
-Rake::RDocTask.new do |rdoc|
-  version = File.exist?('VERSION') ? File.read('VERSION') : ""
-
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title = "attr_symbol #{version}"
-  rdoc.rdoc_files.include('README*')
-  rdoc.rdoc_files.include('lib/**/*.rb')
-end
+# require 'rake/rdoctask'
+# Rake::RDocTask.new do |rdoc|
+#   version = File.exist?('VERSION') ? File.read('VERSION') : ""
+# 
+#   rdoc.rdoc_dir = 'rdoc'
+#   rdoc.title = "attr_symbol #{version}"
+#   rdoc.rdoc_files.include('README*')
+#   rdoc.rdoc_files.include('lib/**/*.rb')
+# end

--- a/attr_symbol.gemspec
+++ b/attr_symbol.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   ]
   s.files = [
     ".document",
-    ".rvmrc",
     "LICENSE",
     "README.rdoc",
     "Rakefile",
@@ -31,7 +30,7 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/jwinky/attr_symbol}
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
-  s.summary = %q{Declare one or more ActiveRecord attributes stored in string columns to be returned as symbols.}
+  s.summary = %q{Declare one or more attributes stored in string columns to be returned as symbols.}
   s.test_files = [
     "test/helper.rb",
     "test/test_attr_symbol.rb"
@@ -42,15 +41,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<shoulda>, [">= 2.11.3"])
-      s.add_runtime_dependency(%q<activerecord>, [">= 2.3.5"])
+      s.add_runtime_dependency(%q<activerecord>, ["~> 2.3.5"])
     else
-      s.add_dependency(%q<shoulda>, [">= 2.11.3"])
-      s.add_dependency(%q<activerecord>, [">= 2.3.5"])
+      s.add_dependency(%q<activerecord>, ["~> 2.3.5"])
     end
   else
-    s.add_dependency(%q<shoulda>, [">= 2.11.3"])
-    s.add_dependency(%q<activerecord>, [">= 2.3.5"])
+    s.add_dependency(%q<activerecord>, ["~> 2.3.5"])
   end
 end
 

--- a/attr_symbol.gemspec
+++ b/attr_symbol.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
     "LICENSE",
     "README.rdoc",
     "Rakefile",
+    "Gemfile",
     "VERSION",
     "attr_symbol.gemspec",
     "lib/attr_symbol.rb",
@@ -35,18 +36,5 @@ Gem::Specification.new do |s|
     "test/helper.rb",
     "test/test_attr_symbol.rb"
   ]
-
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activerecord>, ["~> 2.3.5"])
-    else
-      s.add_dependency(%q<activerecord>, ["~> 2.3.5"])
-    end
-  else
-    s.add_dependency(%q<activerecord>, ["~> 2.3.5"])
-  end
 end
 

--- a/lib/attr_symbol.rb
+++ b/lib/attr_symbol.rb
@@ -1,24 +1,40 @@
-module ActiveRecord::AttrSymbol
+require 'pathname'
 
-  def self.included(base)
-    base.extend ClassMethods
+class Module
+  def attr_symbol(*attributes)
+    attributes.each do |attribute|
+      attr_reader attribute.to_sym
+      
+      define_method("#{attribute}=") { |value| instance_variable_set("@#{attribute}", value.to_sym) }
+    end
   end
-
-  module ClassMethods
-
-    def attr_symbol(*attributes)
-      attributes.each do |attr|
-        define_method(attr) do
-          self[attr].try(:to_sym)
-        end
-
-        define_method("#{attr}=") do |value|
-          self[attr] = value.blank? ? nil : value.try(:to_s)
-        end
-      end
-    end    
-  end
-
 end
 
-ActiveRecord::Base.send(:include, ActiveRecord::AttrSymbol)
+if defined?(ActiveRecord)
+  module ActiveRecord::AttrSymbol
+    VERSION = Pathname.new(__FILE__).join('../../VERSION').read.strip
+    
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+    
+    module ClassMethods
+      
+      def attr_symbol(*attributes)
+        attributes.each do |attribute|
+          define_method(attribute) do
+            self[attribute].try(:to_sym)
+          end
+          
+          define_method("#{attribute}=") do |value|
+            self[attribute] = value.blank? ? nil : value.try(:to_s)
+          end
+        end
+      end
+      
+    end
+    
+  end
+  
+  ActiveRecord::Base.send(:include, ActiveRecord::AttrSymbol)
+end

--- a/lib/attr_symbol.rb
+++ b/lib/attr_symbol.rb
@@ -5,7 +5,7 @@ class Module
     attributes.each do |attribute|
       attr_reader attribute.to_sym
       
-      define_method("#{attribute}=") { |value| instance_variable_set("@#{attribute}", value.to_sym) }
+      define_method("#{attribute}=") { |value| instance_variable_set("@#{attribute}", value.to_s.strip.lines.first.strip.to_sym) }
     end
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'test/unit'
+require 'bundler/setup'
 require 'shoulda'
 require 'active_record'
 

--- a/test/test_attr_symbol.rb
+++ b/test/test_attr_symbol.rb
@@ -7,8 +7,25 @@ class Thing < ActiveRecord::Tableless
   attr_symbol :foo
 end
 
+class Node
+  attr_symbol :type
+  
+  def initialize
+    @type = :resource
+  end
+end
 
 class TestAttrSymbol < Test::Unit::TestCase
+  context "Normal object" do
+    subject { Node.new }
+    
+    should("store the Symbol :collection in the 'type' attribute") do
+      assert_equal :resource, subject.type
+      subject.type = "     \r \n \r\n  \n\r  collection  \r \n \r\n  \n\rlol \r \n \r\n  \n\r     wtf omg "
+      assert_equal :collection, subject.type
+    end
+  end
+  
   context "Setting attribute 'foo'" do
     subject { Thing.new }
 


### PR DESCRIPTION
The library now checks to see if ActiveRecord is defined before defining ActiveRecord specific functionality and makes `attr_symbol` usable in all Objects.

Usage for normal Objects:

``` ruby
class User
  attr_symbol :state

  def initialize
    @state = :inactive
  end
end

u = User.new
p u.state # => :inactive

u.state = 'active'
p u.state # => :active

u.state = "    \r  \n\r  \n \n  inactive \n\r  \n\r    foo filler \r <html lang=\"en\"></html> \r\n \n\n   "
p u.state # => :inactive
```
